### PR TITLE
PRDEV-2608 don't copy line attributes on newline, when new line is empty

### DIFF
--- a/lib/rich-text-codemirror.js
+++ b/lib/rich-text-codemirror.js
@@ -422,8 +422,16 @@ firepad.RichTextCodeMirror = (function () {
       attributes[ATTR.FONT_SIZE] = fsValue;
       className = this.getClassNameForAttributes_(attributes);
     }
-    this.codeMirror.findMarksAt({line: line, ch: (this.codeMirror.getLine(line) || "").length + 1}).forEach(function(mark){
-      if (mark.isForLineSentinel || !mark.className) return;
+    if (cm.getLineHandle(line).text === LineSentinelCharacter) {
+        cm.getLineHandle(line).textClass = '';
+    }
+    this.codeMirror.findMarksAt({
+        line: line,
+        ch: (this.codeMirror.getLine(line) || "").length + 1
+    }).forEach(function(mark){
+      if (mark.isForLineSentinel || !mark.className) {
+        return;
+      }
       if (!className || !mark.className.match(className)) mark.clear();
     });
   };
@@ -1254,8 +1262,15 @@ firepad.RichTextCodeMirror = (function () {
 
         // Copy line attributes forward.
         this.updateLineAttributes(cursorLine+1, cursorLine+1, function(attributes) {
+          var text = cm.getLineHandle(cm.getCursor('head').line).text;
           for(var attr in lineAttributes) {
-            attributes[attr] = lineAttributes[attr];
+              if (text == '') {
+                  // for case when new line added and not old line is split, we want to remove all styles
+                  if (attr == 'l') attributes[attr] = lineAttributes[attr];
+              }
+              else {
+                  attributes[attr] = lineAttributes[attr];
+              }
           }
 
           // Don't mark new todo items as completed.


### PR DESCRIPTION
don't copy line attributes on newline, when new line is empty
- remove textClass inside clearDanglingFontSizeMarksFromLine_

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Make sure your changes pass our linter and the tests all pass on your local machine. We've hooked
up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Updating our documentation? Implementing a new feature? Make sure we
have the context around your change. Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
